### PR TITLE
Issue #4: Change BEAN_METHOD_NOT_IN_CONFIGURATION from error -> warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This project provides a [Java 6 Annotation processor](http://docs.oracle.com/jav
 - @Bean methods must not be private.
 - @Bean methods must not be final.
 - @Bean methods must have a non-void return type.
-- @Bean methods must be declared in classes annotated with @Configuration.
+- @Bean methods should be declared in classes annotated with @Configuration.
 - @Bean methods returning a BeanFactoryPostProcessor should be static.
 - Only @Bean methods returning a BeanFactoryPostProcessor should be static.
 

--- a/config-validation-processor-core/src/main/java/com/github/pellaton/springconfigvalidation/SpringConfigurationMessage.java
+++ b/config-validation-processor-core/src/main/java/com/github/pellaton/springconfigvalidation/SpringConfigurationMessage.java
@@ -45,14 +45,14 @@ public enum SpringConfigurationMessage {
   BEAN_METHOD_RETURNS_VOID(Kind.ERROR,
       "Invalid factory method: @Bean methods must have a non-void return type."),
   BEAN_METHOD_PRIVATE(Kind.ERROR, "Invalid factory method: @Bean methods must not be private."),
-  BEAN_METHOD_NOT_IN_CONFIGURATION(Kind.ERROR,
-      "Invalid factory method: @Bean methods must be declared in classes annotated with @Configuration."),
 
   // warnings on @Bean methods
   STATIC_BEAN_METHOD(Kind.WARNING,
       "Only @Bean methods returning a BeanFactoryPostProcessor should be static."),
   BFPP_BEAN_METHOD_NOT_STATIC(Kind.WARNING,
-      "@Bean methods returning a BeanFactoryPostProcessor should be static.");
+      "@Bean methods returning a BeanFactoryPostProcessor should be static."),
+  BEAN_METHOD_NOT_IN_CONFIGURATION(Kind.WARNING,
+      "Invalid factory method: @Bean methods should be declared in classes annotated with @Configuration.");
 
 
   private final Kind kind;

--- a/config-validation-processor-core/src/main/java/com/github/pellaton/springconfigvalidation/SpringConfigurationValidationProcessor.java
+++ b/config-validation-processor-core/src/main/java/com/github/pellaton/springconfigvalidation/SpringConfigurationValidationProcessor.java
@@ -53,7 +53,7 @@ import javax.lang.model.util.Types;
  * [x] Error: Invalid factory method: @Bean methods must not be private.
  * [x] Error: Invalid factory method: @Bean methods must not be final.
  * [x] Error: Invalid factory method: @Bean methods must have a non-void return type.
- * [x] Error: Invalid factory method: @Bean methods must be declared in classes annotated with @Configuration.
+ * [x] Warn: Invalid factory method: @Bean methods should be declared in classes annotated with @Configuration.
  * [x] Warn:  @Bean methods returning a BeanFactoryPostProcessor should be static.
  * [x] Warn:  Only @Bean methods returning a BeanFactoryPostProcessor should be static.
  * </pre>


### PR DESCRIPTION
Since Spring does explicitly allow @Bean methods in non-configuration
classes (so-called 'lite mode'), the annotation processor should only
issue a warning and not an error.

See
http://docs.spring.io/spring/docs/3.2.x/javadoc-api/org/springframework/context/annotation/Bean.html
