### PR TITLE
Rename Processor for Java 8

### DIFF
--- a/config-validation-processor-java8/src/main/java/com/github/pellaton/springconfigvalidation/SpringConfigurationValidationProcessorJava8.java
+++ b/config-validation-processor-java8/src/main/java/com/github/pellaton/springconfigvalidation/SpringConfigurationValidationProcessorJava8.java
@@ -31,6 +31,6 @@ import javax.lang.model.SourceVersion;
 @SupportedAnnotationTypes({
   "org.springframework.context.annotation.Configuration", "org.springframework.context.annotation.Bean"})
 @SupportedSourceVersion(SourceVersion.RELEASE_8)
-public class SpringConfigurationValidationProcessorJava7 extends SpringConfigurationValidationProcessor {
+public class SpringConfigurationValidationProcessorJava8 extends SpringConfigurationValidationProcessor {
 
 }


### PR DESCRIPTION
The processor for Java 8 should have an 8 and not a 7 in the name.